### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,8 +71,10 @@ RUN mkdir -p /app/outputs && \
 
 # Copy entrypoint script
 COPY entrypoint.sh /entrypoint.sh
+USER root
 RUN chmod +x /entrypoint.sh && \
     chown $UID:$GID /entrypoint.sh
+USER $UID:$GID
 
 EXPOSE 7860
 


### PR DESCRIPTION
When Linux user UID is not 100, the copied entrypoint.sh is not allowed to change owner by UID 100.
So temporary change USER to root.